### PR TITLE
Keeps the TLoad graph on home page for duration of user session

### DIFF
--- a/TriathlonMetricAnalyzer/Controllers/HomeController.cs
+++ b/TriathlonMetricAnalyzer/Controllers/HomeController.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using TriathlonMetricAnalyzer.Models;
 using TriathlonMetricAnalyzer.Models.StravaAPIClient;
 using TriathlonMetricAnalyzer.Models.StravaAPIObjects;
+using TriathlonMetricAnalyzer.Models.CalculationTools;
 
 namespace TriathlonMetricAnalyzer.Controllers
 {
@@ -24,8 +25,22 @@ namespace TriathlonMetricAnalyzer.Controllers
             {
                 DetailedAthlete athlete = JsonConvert.DeserializeObject<DetailedAthlete>(HttpContext.Session.GetString("AthleteDetails"));
                 ViewBag.Athlete = athlete.FirstName + " " + athlete.LastName;
+                if (HttpContext.Session.GetString("SummaryActivities") == null)
+                {
+                    ViewBag.ErrorMessage = "There was an error processing your request.";
+                    return View("Home", "Index");
+                }
+                JsonSerializerSettings settings = new JsonSerializerSettings();
+                settings.NullValueHandling = NullValueHandling.Ignore;
+                List<SummaryActivity> activities = JsonConvert.DeserializeObject<List<SummaryActivity>>(HttpContext.Session.GetString("SummaryActivities"), settings);
+                ViewBag.TLoad = TLoadCalculator.CalculateTLoadLast7Days(activities);
+                return View("~/Views/Home/Index.cshtml");
             }
-            return View();
+            else
+            {
+                return View();
+            }
+            
         }
 
         public IActionResult Authorize()

--- a/TriathlonMetricAnalyzer/Controllers/MetricsController.cs
+++ b/TriathlonMetricAnalyzer/Controllers/MetricsController.cs
@@ -10,57 +10,6 @@ namespace TriathlonMetricAnalyzer.Controllers
 {
     public class MetricsController : Controller
     {
-
-        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
-        public IActionResult CalculateTLoad()
-        {
-            if (HttpContext.Session.GetString("SummaryActivities") == null)
-            {
-                ViewBag.ErrorMessage = "There was an error processing your request.";
-                return View("Home", "Index");
-            }
-            List<float> TLoad = new List<float>() { 0, 0, 0, 0, 0, 0, 0, 0 };
-            JsonSerializerSettings settings = new JsonSerializerSettings();
-            settings.NullValueHandling = NullValueHandling.Ignore;
-            List<SummaryActivity> activities = JsonConvert.DeserializeObject<List<SummaryActivity>>(HttpContext.Session.GetString("SummaryActivities"), settings);
-            foreach (SummaryActivity activity in activities)
-            {
-                DateTime startDateAtMidnight = activity.StartDate.Date;
-                int daysDifference = (DateTime.Today - startDateAtMidnight).Days;
-                if (daysDifference < 7)
-                {
-                    TLoad[7] += (activity.Distance / activity.MovingTime) * 1; // the 1 is a place holder for a future calculated intensity factor
-
-                    switch (daysDifference)
-                    {
-                        case 0:
-                            TLoad[0] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 1:
-                            TLoad[1] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 2:
-                            TLoad[2] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 3:
-                            TLoad[3] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 4:
-                            TLoad[4] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 5:
-                            TLoad[5] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                        case 6:
-                            TLoad[6] += (activity.Distance / activity.MovingTime) * 1;
-                            continue;
-                    }
-                }
-            }
-            ViewBag.TLoad = TLoad;
-            return View("~/Views/Home/Index.cshtml");
-        }
-
         public async Task<IActionResult> CalculateZones()
         {
             JsonSerializerSettings settings = new JsonSerializerSettings();

--- a/TriathlonMetricAnalyzer/Controllers/StravaOAuthController.cs
+++ b/TriathlonMetricAnalyzer/Controllers/StravaOAuthController.cs
@@ -33,7 +33,7 @@ namespace TriathlonMetricAnalyzer.Controllers
                 TokenResponse tokenResponse = JsonConvert.DeserializeObject<TokenResponse>(HttpContext.Session.GetString("UserToken"));
                 HttpContext.Session.SetString("AthleteDetails", await StravaAPIClient.SendStravaGetAuthenticateAthleteRequest(tokenResponse.AccessToken));
                 HttpContext.Session.SetString("SummaryActivities", await StravaAPIClient.SendStravaListAthleteActivitiesRequest(tokenResponse.AccessToken));
-                return RedirectToAction("CalculateTLoad", "Metrics");
+                return RedirectToAction("Index", "Home");
             }
             else
             {

--- a/TriathlonMetricAnalyzer/Models/CalculationTools/TLoadCalculator.cs
+++ b/TriathlonMetricAnalyzer/Models/CalculationTools/TLoadCalculator.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using TriathlonMetricAnalyzer.Models.StravaAPIObjects;
+
+namespace TriathlonMetricAnalyzer.Models.CalculationTools
+{
+    public static class TLoadCalculator
+    {
+        public static List<float> CalculateTLoadLast7Days(List<SummaryActivity> SummaryActivities)
+        {
+            List<float> TLoad = new List<float>() { 0, 0, 0, 0, 0, 0, 0, 0 };
+            foreach (SummaryActivity activity in SummaryActivities)
+            {
+                DateTime startDateAtMidnight = activity.StartDate.Date;
+                int daysDifference = (DateTime.Today - startDateAtMidnight).Days;
+                if (daysDifference < 7)
+                {
+                    TLoad[7] += (activity.Distance / activity.MovingTime) * 1; // the 1 is a place holder for a future calculated intensity factor
+
+                    switch (daysDifference)
+                    {
+                        case 0:
+                            TLoad[0] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 1:
+                            TLoad[1] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 2:
+                            TLoad[2] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 3:
+                            TLoad[3] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 4:
+                            TLoad[4] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 5:
+                            TLoad[5] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                        case 6:
+                            TLoad[6] += (activity.Distance / activity.MovingTime) * 1;
+                            continue;
+                    }
+                }
+            }
+            return TLoad;
+        }
+    }
+}


### PR DESCRIPTION
The T Load graph is now kept on the home page until the user quits the session the T Load calculation was also refactored into a Model under Calculation Tools making it possible to expand the calculator to calculate T load over different time intervals fixes #12 and fixes #23